### PR TITLE
more coverage

### DIFF
--- a/backend/remote-state/nxrm/client_test.go
+++ b/backend/remote-state/nxrm/client_test.go
@@ -18,6 +18,23 @@ func TestGetNXRMURL(t *testing.T) {
 	}
 }
 
+func TestGetNXRMURLTrimUrl(t *testing.T) {
+	testConfg := map[string]interface{}{
+		"url":       "http://localhost:8081/repository/tf-backend/",
+		"subpath":   "this/here",
+		"username":  "",
+		"password":  "",
+		"stateName": "demo.tfstate",
+	}
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(testConfg)).(*Backend)
+
+	url := b.client.getNXRMURL(b.client.stateName)
+
+	if url != `http://localhost:8081/repository/tf-backend/this/here/demo.tfstate` {
+		t.Fatalf("getNXRMURL mismatch: %s", url)
+	}
+}
+
 func TestGetHTTPClient(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 	expectedTimeout := time.Second * time.Duration(config["timeout"].(int))

--- a/backend/remote-state/nxrm/client_test.go
+++ b/backend/remote-state/nxrm/client_test.go
@@ -35,6 +35,25 @@ func TestGetNXRMURLTrimUrl(t *testing.T) {
 	}
 }
 
+func TestGetNXRMURLTrimSubpath(t *testing.T) {
+	testConfg := map[string]interface{}{
+		"url":       "http://localhost:8081/repository/tf-backend",
+		"subpath":   "this/here",
+		"username":  "",
+		"password":  "",
+		"stateName": "demo.tfstate",
+	}
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(testConfg)).(*Backend)
+
+	// force mutation, avoid effect of ValidateFunc()
+	b.client.subpath = "this/here/"
+	url := b.client.getNXRMURL(b.client.stateName)
+
+	if url != `http://localhost:8081/repository/tf-backend/this/here/demo.tfstate` {
+		t.Fatalf("getNXRMURL mismatch: %s", url)
+	}
+}
+
 func TestGetHTTPClient(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 	expectedTimeout := time.Second * time.Duration(config["timeout"].(int))


### PR DESCRIPTION
A couple tests to cover the `getNXRMURL()` function.

Not sure about the second one that forcibly mutates the "validated" value. If we decide to not to test this path, we should probably remove it from the `getNXRMURL()` function.

If there are other places you'd prefer I focus, please holler.